### PR TITLE
Add Modbus float32 mapping.

### DIFF
--- a/codegen/src/main/java/com/oes/openfmb/generation/enumeration/Enumerations.java
+++ b/codegen/src/main/java/com/oes/openfmb/generation/enumeration/Enumerations.java
@@ -158,7 +158,8 @@ public class Enumerations {
                         Enumeration.entry("sint32", "32-bit signed register, formed from two modbus 16-bit registers"),
                         Enumeration.entry("uint32", "32-bit unsigned register, formed from two modbus 16-bit registers"),
                         Enumeration.entry("sint32_with_modulus", "32-bit signed register, formed from two modbus 16-bit registers, custom modulus"),
-                        Enumeration.entry("uint32_with_modulus", "32-bit unsigned register, formed from two modbus 16-bit registers, custom modulus")
+                        Enumeration.entry("uint32_with_modulus", "32-bit unsigned register, formed from two modbus 16-bit registers, custom modulus"),
+                        Enumeration.entry("float32", "32-bit IEEE 754 floating point value")
                 )
         );
 

--- a/plugins/modbus/src/modbus/ICachedValue.h
+++ b/plugins/modbus/src/modbus/ICachedValue.h
@@ -37,6 +37,8 @@ namespace modbus {
         virtual uint32_t to_uint32(uint32_t modulus) const = 0;
 
         virtual int32_t to_sint32(uint32_t modulus) const = 0;
+
+        virtual float to_float32() const = 0;
     };
 }
 }

--- a/plugins/modbus/src/modbus/MultipleRegisterEnumMapping.h
+++ b/plugins/modbus/src/modbus/MultipleRegisterEnumMapping.h
@@ -48,7 +48,7 @@ namespace modbus {
             const std::shared_ptr<SharedValue> shared_value;
 
         public:
-            RegisterAction(uint8_t bit, uint8_t position, std::shared_ptr<SharedValue> shared_value)
+            RegisterAction(uint8_t bit, uint16_t position, std::shared_ptr<SharedValue> shared_value)
                 : bit_mask(static_cast<uint16_t>(1) << bit)
                 , or_mask(static_cast<uint16_t>(1) << position)
                 , shared_value(std::move(shared_value))

--- a/plugins/modbus/src/modbus/PublishConfigReadVisitor.h
+++ b/plugins/modbus/src/modbus/PublishConfigReadVisitor.h
@@ -215,6 +215,11 @@ namespace modbus {
                 accessor->set(profile, static_cast<float>(reg->to_sint32(modulus) * scale));
             });
             break;
+        case (RegisterMapping::Value::float32):
+            this->map_register32(node, [accessor, scale = util::yaml::get::scale(node)](T& profile, const std::shared_ptr<Register32>& reg, api::Logger&) {
+                accessor->set(profile, static_cast<float>(reg->to_float32() * scale));
+            });
+            break;
         default:
             throw api::Exception("Unhandled register mapping type for float: ", RegisterMapping::to_string(mapping));
         }

--- a/plugins/modbus/src/modbus/generated/RegisterMapping.cpp
+++ b/plugins/modbus/src/modbus/generated/RegisterMapping.cpp
@@ -27,8 +27,9 @@ const char RegisterMapping::sint32[] = "sint32";
 const char RegisterMapping::uint32[] = "uint32";
 const char RegisterMapping::sint32_with_modulus[] = "sint32_with_modulus";
 const char RegisterMapping::uint32_with_modulus[] = "uint32_with_modulus";
+const char RegisterMapping::float32[] = "float32";
 
-const std::array<RegisterMapping::Value, 6> RegisterMapping::values =
+const std::array<RegisterMapping::Value, 7> RegisterMapping::values =
 {
     RegisterMapping::Value::sint16,
     RegisterMapping::Value::uint16,
@@ -36,6 +37,7 @@ const std::array<RegisterMapping::Value, 6> RegisterMapping::values =
     RegisterMapping::Value::uint32,
     RegisterMapping::Value::sint32_with_modulus,
     RegisterMapping::Value::uint32_with_modulus,
+    RegisterMapping::Value::float32,
 };
 
 std::string RegisterMapping::to_string(RegisterMapping::Value value)
@@ -47,7 +49,8 @@ std::string RegisterMapping::to_string(RegisterMapping::Value value)
         case(Value::sint32): return sint32;
         case(Value::uint32): return uint32;
         case(Value::sint32_with_modulus): return sint32_with_modulus;
-        default: return uint32_with_modulus;
+        case(Value::uint32_with_modulus): return uint32_with_modulus;
+        default: return float32;
     }
 }
 
@@ -61,6 +64,7 @@ RegisterMapping::Value RegisterMapping::from_string(const std::string& name)
         {uint32, Value::uint32},
         {sint32_with_modulus, Value::sint32_with_modulus},
         {uint32_with_modulus, Value::uint32_with_modulus},
+        {float32, Value::float32},
     };
     const auto elem = map.find(name);
     if(elem == map.end()) throw api::Exception("Unknown value name '", name, "' for enum RegisterMapping");

--- a/plugins/modbus/src/modbus/generated/RegisterMapping.h
+++ b/plugins/modbus/src/modbus/generated/RegisterMapping.h
@@ -37,6 +37,8 @@ struct RegisterMapping
         sint32_with_modulus,
         // 32-bit unsigned register, formed from two modbus 16-bit registers, custom modulus
         uint32_with_modulus,
+        // 32-bit IEEE 754 floating point value
+        float32,
     };
 
     static const char sint16[];
@@ -45,10 +47,11 @@ struct RegisterMapping
     static const char uint32[];
     static const char sint32_with_modulus[];
     static const char uint32_with_modulus[];
+    static const char float32[];
 
     static constexpr const char* label = "register-mapping";
 
-    static const std::array<Value, 6> values;
+    static const std::array<Value, 7> values;
 
     static std::string to_string(Value value);
     static Value from_string(const std::string& name);

--- a/plugins/modbus/test/test_register_conversions.cpp
+++ b/plugins/modbus/test/test_register_conversions.cpp
@@ -56,11 +56,74 @@ TEST_CASE("32-bit registers function as expected")
 
     SECTION("converts to uint32 modulo 10K")
     {
-
         Register32 value;
         value.get_upper()->set(1234);
         value.get_lower()->set(5678);
         // 1234*10000 + 5678 = 123455679
         REQUIRE(value.to_uint32(10000) == 12345678);
+    }
+
+    SECTION("converts to float32 correctly")
+    {
+        SECTION("Zero")
+        {
+            Register32 value;
+            value.get_upper()->set(0x0000);
+            value.get_lower()->set(0x0000);
+            REQUIRE(value.to_float32() == Approx(0.0f));
+        }
+
+        SECTION("Positive number")
+        {
+            Register32 value;
+            value.get_upper()->set(0x4228);
+            value.get_lower()->set(0xCCCD);
+            REQUIRE(value.to_float32() == Approx(42.2f));
+        }
+
+        SECTION("Negative number")
+        {
+            Register32 value;
+            value.get_upper()->set(0xC299);
+            value.get_lower()->set(0x3333);
+            REQUIRE(value.to_float32() == Approx(-76.6f));
+        }
+
+        SECTION("Fraction number")
+        {
+            Register32 value;
+            value.get_upper()->set(0x3DFC);
+            value.get_lower()->set(0xB924);
+            REQUIRE(value.to_float32() == Approx(0.1234f));
+        }
+
+        SECTION("NaN")
+        {
+            Register32 value;
+            value.get_upper()->set(0xFFC0);
+            value.get_lower()->set(0x0000);
+            auto result = value.to_float32();
+            REQUIRE(std::isnan(result));
+        }
+
+        SECTION("+Infinity")
+        {
+            Register32 value;
+            value.get_upper()->set(0x7F80);
+            value.get_lower()->set(0x0000);
+            auto result = value.to_float32();
+            REQUIRE(std::isinf(result));
+            REQUIRE(result > 0);
+        }
+
+        SECTION("-Infinity")
+        {
+            Register32 value;
+            value.get_upper()->set(0xFF80);
+            value.get_lower()->set(0x0000);
+            auto result = value.to_float32();
+            REQUIRE(std::isinf(result));
+            REQUIRE(result < 0);
+        }
     }
 }


### PR DESCRIPTION
Closes #45.

- Add a `float32` mapping type, that reads an IEEE 754 float value from two Modbus registers.
- The lower and upper indices are specified separately, so it does support MSR and LSR as requested.
- The IEEE 754 parsing is heavily inspired by what I done in `goose-cpp`, and is platform agnostic.