### PR TITLE
Specify network adapter in Modbus.

### DIFF
--- a/deps/exe4cpp.cmake
+++ b/deps/exe4cpp.cmake
@@ -2,9 +2,8 @@ include(FetchContent)
 
 FetchContent_Declare(
     exe4cpp
-    GIT_REPOSITORY https://github.com/automatak/exe4cpp.git
-    GIT_TAG        asio-1-12-2
-    GIT_SHALLOW    ON
+    URL      https://github.com/automatak/exe4cpp/archive/fb878a4de598ba9d6e4338afebf83f96e03af1b8.zip
+    URL_HASH SHA1=18B141E8CF09DC8D28CC62DD5FA2920670D501BD
 )
 
 FetchContent_GetProperties(exe4cpp)

--- a/deps/goose-cpp.cmake
+++ b/deps/goose-cpp.cmake
@@ -3,8 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     goose-cpp
     GIT_REPOSITORY git@github.com:openenergysolutions/goose-cpp.git
-    GIT_TAG        develop
-    GIT_SHALLOW    ON
+    GIT_TAG        6e576b73a89892a609bfac1d124c82491ca1a6fc
 )
 
 FetchContent_GetProperties(goose-cpp)

--- a/deps/log4cpp.cmake
+++ b/deps/log4cpp.cmake
@@ -2,9 +2,8 @@ include(FetchContent)
 
 FetchContent_Declare(
     log4cpp
-    GIT_REPOSITORY https://github.com/automatak/log4cpp.git
-    GIT_TAG        master
-    GIT_SHALLOW    ON
+    URL      https://github.com/automatak/log4cpp/archive/5e54dbdbf80712f472baa1a72e25e505d62f05bd.zip
+    URL_HASH SHA1=9F2653C3F98762B743054B7547F50132031684CF
 )
 
 FetchContent_GetProperties(log4cpp)

--- a/deps/modbus-cpp.cmake
+++ b/deps/modbus-cpp.cmake
@@ -3,8 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     modbus-cpp
     GIT_REPOSITORY git@github.com:openenergysolutions/modbus-cpp.git
-    GIT_TAG        master
-    GIT_SHALLOW    ON
+    GIT_TAG        e22d21f79f0e6267ae0aa68ce5b8f6ae67dba18e
 )
 
 FetchContent_GetProperties(modbus-cpp)

--- a/deps/opendnp3.cmake
+++ b/deps/opendnp3.cmake
@@ -2,9 +2,8 @@ include(FetchContent)
 
 FetchContent_Declare(
     opendnp3
-    GIT_REPOSITORY https://github.com/dnp3/opendnp3.git
-    GIT_TAG        develop
-    GIT_SHALLOW    ON
+    URL      https://github.com/dnp3/opendnp3/archive/c1e43b9b38094f222af04cba31dcffb9bdb95bf9.zip
+    URL_HASH SHA1=91DBC4D504925ABFAF2D25FD6FA2328F65262478
 )
 
 FetchContent_GetProperties(opendnp3)

--- a/deps/ser4cpp.cmake
+++ b/deps/ser4cpp.cmake
@@ -2,9 +2,8 @@ include(FetchContent)
 
 FetchContent_Declare(
     ser4cpp
-    GIT_REPOSITORY https://github.com/automatak/ser4cpp.git
-    GIT_TAG        master
-    GIT_SHALLOW    ON
+    URL      https://github.com/automatak/ser4cpp/archive/3c449734dc530a8f465eb0982de29165cc4e23d5.zip
+    URL_HASH SHA1=937B759B7CC80180DA26B47037E796B59798A672
 )
 
 FetchContent_GetProperties(ser4cpp)

--- a/plugins/modbus/src/modbus/ConfigStrings.h
+++ b/plugins/modbus/src/modbus/ConfigStrings.h
@@ -13,6 +13,7 @@ namespace modbus {
         constexpr const char* const log_level = "log-level";
         constexpr const char* const remote_ip = "remote-ip";
         constexpr const char* const port = "port";
+        constexpr const char* const adapter = "adapter";
         constexpr const char* const unit_identifier = "unit-identifier";
         constexpr const char* const always_write_multiple_registers = "always-write-multiple-registers";
 

--- a/plugins/modbus/src/modbus/Plugin.cpp
+++ b/plugins/modbus/src/modbus/Plugin.cpp
@@ -179,6 +179,7 @@ namespace modbus {
             ::modbus::Ipv4Endpoint(
                 util::yaml::require_string(node, keys::remote_ip),
                 util::yaml::require_integer<uint16_t>(node, keys::port)),
+            util::yaml::require_string(node, keys::adapter),
             log_level);
 
         const auto session = channel->create_session(

--- a/plugins/modbus/src/modbus/PluginFactory.cpp
+++ b/plugins/modbus/src/modbus/PluginFactory.cpp
@@ -70,6 +70,7 @@ namespace modbus {
         out << YAML::Key << keys::log_level << YAML::Value << "Info" << YAML::Comment(util::enumeration::get_value_set<LogLevel>());
         out << YAML::Key << keys::remote_ip << YAML::Value << "127.0.0.1";
         out << YAML::Key << keys::port << YAML::Value << 502;
+        out << YAML::Key << keys::adapter << YAML::Value << "0.0.0.0";
         out << YAML::Key << keys::unit_identifier << YAML::Value << 1 << YAML::Comment("aka 'slave address'");
 
         out << YAML::Key << keys::response_timeout_ms << YAML::Value << 1000 << YAML::Comment("response timeout");


### PR DESCRIPTION
- The modbus plugin now takes an extra `adapter` used to specify which network adapter to use when connecting. A value of `"0.0.0.0"` should use the default adapter.
- The dependencies are now specified to a particular commit hash to make the builds reproducible.