### PR TITLE
[DNP3 Outstation] Add various int32/int64 support

### DIFF
--- a/plugins/dnp3/src/dnp3/outstation/ControlConfigWriteVisitor.cpp
+++ b/plugins/dnp3/src/dnp3/outstation/ControlConfigWriteVisitor.cpp
@@ -43,22 +43,17 @@ namespace dnp3 {
 
         void ControlConfigWriteVisitor::write_mapped_int32_keys(YAML::Emitter& out)
         {
-            // throw api::Exception("int32 mapping not supported in DNP3 outstation control profiles");
+            write_mapped_numeric_keys(out);
         }
 
         void ControlConfigWriteVisitor::write_mapped_int64_keys(YAML::Emitter& out)
         {
-            // throw api::Exception("int64 mapping not supported in DNP3 outstation control profiles");
+            write_mapped_numeric_keys(out);
         }
 
         void ControlConfigWriteVisitor::write_mapped_float_keys(YAML::Emitter& out)
         {
-            out << YAML::Key << CommandSourceType::label << YAML::Value << CommandSourceType::none;
-            out << YAML::Comment(util::enumeration::get_value_set_from_list<CommandSourceType>({ CommandSourceType::Value::none, CommandSourceType::Value::analog_output }));
-            out << YAML::Key << ProfileAction::label << YAML::Value << ProfileAction::update;
-            out << YAML::Comment(util::enumeration::get_value_set<ProfileAction>());
-            out << YAML::Key << util::keys::index << YAML::Value << 0;
-            out << YAML::Key << util::keys::scale << YAML::Value << 1.0;
+            write_mapped_numeric_keys(out);
         }
 
         void ControlConfigWriteVisitor::write_mapped_enum_keys(YAML::Emitter& out,
@@ -86,6 +81,16 @@ namespace dnp3 {
         void ControlConfigWriteVisitor::write_mapped_schedule_parameter_keys(YAML::Emitter& out)
         {
             //throw api::Exception("schedule parameter mapping not supported in DNP3 outstation control profiles");
+        }
+
+        void ControlConfigWriteVisitor::write_mapped_numeric_keys(YAML::Emitter& out)
+        {
+            out << YAML::Key << CommandSourceType::label << YAML::Value << CommandSourceType::none;
+            out << YAML::Comment(util::enumeration::get_value_set_from_list<CommandSourceType>({ CommandSourceType::Value::none, CommandSourceType::Value::analog_output }));
+            out << YAML::Key << ProfileAction::label << YAML::Value << ProfileAction::update;
+            out << YAML::Comment(util::enumeration::get_value_set<ProfileAction>());
+            out << YAML::Key << util::keys::index << YAML::Value << 0;
+            out << YAML::Key << util::keys::scale << YAML::Value << 1.0;
         }
     }
 }

--- a/plugins/dnp3/src/dnp3/outstation/ControlConfigWriteVisitor.h
+++ b/plugins/dnp3/src/dnp3/outstation/ControlConfigWriteVisitor.h
@@ -34,6 +34,9 @@ namespace dnp3 {
             write_mapped_enum_keys(YAML::Emitter& out, google::protobuf::EnumDescriptor const* descriptor) override;
 
             void write_mapped_schedule_parameter_keys(YAML::Emitter& out) override;
+
+        private:
+            void write_mapped_numeric_keys(YAML::Emitter& out);
         };
     }
 }

--- a/plugins/dnp3/src/dnp3/outstation/MeasurementConfigWriteVisitor.cpp
+++ b/plugins/dnp3/src/dnp3/outstation/MeasurementConfigWriteVisitor.cpp
@@ -38,7 +38,9 @@ namespace dnp3 {
 
         void MeasurementConfigWriteVisitor::write_mapped_int32_keys(YAML::Emitter& out)
         {
-            out << YAML::Comment("int32 mapping not supported in DNP3 outstation measurement profiles");
+            write_scaled_keys(
+                out,
+                { DestinationType::Value::none, DestinationType::Value::analog, DestinationType::Value::counter });
         }
 
         void MeasurementConfigWriteVisitor::write_mapped_int64_keys(YAML::Emitter& out)


### PR DESCRIPTION
While writing the documentation for the DNP3 outstation plugin, I saw these easy-to-do just-one-template-away changes to add more consistent support.

- In control profiles, added support for int32 and int64 from Analog Output commands.
- In non-control profiles, added support for int32 mappings (exactly like int64).