### PR TITLE
upgrade to opendnp3 3.0

### DIFF
--- a/deps/opendnp3.cmake
+++ b/deps/opendnp3.cmake
@@ -2,8 +2,7 @@ include(FetchContent)
 
 FetchContent_Declare(
     opendnp3
-    URL      https://github.com/dnp3/opendnp3/archive/c1e43b9b38094f222af04cba31dcffb9bdb95bf9.zip
-    URL_HASH SHA1=91DBC4D504925ABFAF2D25FD6FA2328F65262478
+    URL      https://github.com/dnp3/opendnp3/archive/3.0.3.zip
 )
 
 FetchContent_GetProperties(opendnp3)

--- a/plugins/dnp3/src/dnp3/ConfigStrings.h
+++ b/plugins/dnp3/src/dnp3/ConfigStrings.h
@@ -23,7 +23,8 @@ namespace dnp3 {
         constexpr const char* const outstation_address = "outstation-address";
 
         // master application layer
-        constexpr const char* const control_code = "control_code";
+        constexpr const char* const operation_type = "operation-type";
+        constexpr const char* const trip_close_code = "trip-close-code";
         constexpr const char* const unsolicited_poll_name = "unsolicited";
         constexpr const char* const unsolicited_class_1 = "unsol-class-1";
         constexpr const char* const unsolicited_class_2 = "unsol-class-2";

--- a/plugins/dnp3/src/dnp3/LogAdapter.h
+++ b/plugins/dnp3/src/dnp3/LogAdapter.h
@@ -2,15 +2,15 @@
 #ifndef OPENFMB_ADAPTER_LOGADAPTER_H
 #define OPENFMB_ADAPTER_LOGADAPTER_H
 
-#include <opendnp3/LogLevels.h>
-#include <log4cpp/ILogHandler.h>
+#include <opendnp3/logging/LogLevels.h>
+#include <opendnp3/logging/ILogHandler.h>
 
 #include <adapter-api/Logger.h>
 
 namespace adapter {
 namespace dnp3 {
 
-    class LogAdapter final : public log4cpp::ILogHandler {
+    class LogAdapter final : public opendnp3::ILogHandler {
 
         api::Logger logger;
 
@@ -20,7 +20,7 @@ namespace dnp3 {
         {
         }
 
-        virtual void log(log4cpp::ModuleId module, const char* id, log4cpp::LogLevel level, char const* location, char const* message)
+        virtual void log(opendnp3::ModuleId module, const char* id, opendnp3::LogLevel level, char const* location, char const* message)
         {
             if(level == opendnp3::flags::DBG) logger.debug("[{}] - {}", id, message);
             else if(level == opendnp3::flags::INFO) logger.info("[{}] - {}", id, message);

--- a/plugins/dnp3/src/dnp3/master/Control.cpp
+++ b/plugins/dnp3/src/dnp3/master/Control.cpp
@@ -5,7 +5,8 @@
 #include <adapter-util/config/YAMLGetters.h>
 #include <adapter-util/util/YAMLUtil.h>
 
-#include <opendnp3/gen/ControlCode.h>
+#include <opendnp3/gen/TripCloseCode.h>
+#include <opendnp3/gen/OperationType.h>
 
 #include "dnp3/ConfigStrings.h"
 
@@ -13,7 +14,8 @@ namespace adapter {
 namespace dnp3 {
     namespace master {
 
-        constexpr const char* const control_code = "control-code";
+        constexpr const char* const trip_close_code = "trip-close-code";
+        constexpr const char* const operation_type = "operation-type";
         constexpr const char* const count = "count";
         constexpr const char* const on_time_ms = "on-time-ms";
         constexpr const char* const off_time_ms = "off-time-ms";
@@ -29,24 +31,14 @@ namespace dnp3 {
             return Control{
                 util::yaml::get::index(node),
                 opendnp3::ControlRelayOutputBlock{
-                    opendnp3::ControlCodeSpec::from_string(util::yaml::require_string(node, control_code)),
+                    opendnp3::OperationTypeSpec::from_string(util::yaml::require_string(node, operation_type)),
+                    opendnp3::TripCloseCodeSpec::from_string(util::yaml::require_string(node, trip_close_code)),
+                    false,
                     util::yaml::require_integer<uint8_t>(node, count),
                     util::yaml::require_integer<uint32_t>(node, on_time_ms),
                     util::yaml::require_integer<uint32_t>(node, off_time_ms) }
             };
-        }
-
-        void Control::write(const Control& control, YAML::Emitter& out)
-        {
-            out << YAML::Key << util::keys::index << YAML::Value << control.index;
-            out << YAML::Key << util::keys::command_id << YAML::Value << "some-command-id";
-
-            out << YAML::Key << control_code << YAML::Value
-                << opendnp3::ControlCodeSpec::to_string(control.crob.functionCode);
-            out << YAML::Key << count << YAML::Value << static_cast<int>(control.crob.count);
-            out << YAML::Key << on_time_ms << YAML::Value << control.crob.onTimeMS;
-            out << YAML::Key << off_time_ms << YAML::Value << control.crob.offTimeMS;
-        }
+        }        
     }
 }
 }

--- a/plugins/dnp3/src/dnp3/master/Control.h
+++ b/plugins/dnp3/src/dnp3/master/Control.h
@@ -10,17 +10,15 @@ namespace dnp3 {
     namespace master {
 
         /**
-             * Control is a index + CROB w/ static helper methods for YAML (de)serialization
-             */
+        * Control is a index + CROB w/ static helper methods for YAML (de)serialization
+        */
         struct Control {
             uint16_t index;
             opendnp3::ControlRelayOutputBlock crob;
 
             Control(uint16_t index, const opendnp3::ControlRelayOutputBlock& crob);
 
-            static Control read(const YAML::Node& node);
-
-            static void write(const Control& control, YAML::Emitter& out);
+            static Control read(const YAML::Node& node);            
         };
     }
 }

--- a/plugins/dnp3/src/dnp3/master/ControlSchemaWriteVisitor.cpp
+++ b/plugins/dnp3/src/dnp3/master/ControlSchemaWriteVisitor.cpp
@@ -8,6 +8,9 @@
 #include "dnp3/generated/CommandActionType.h"
 #include "dnp3/generated/SourceType.h"
 
+#include <opendnp3/gen/OperationType.h>
+#include <opendnp3/gen/TripCloseCode.h>
+
 using namespace adapter::schema;
 
 namespace adapter {
@@ -106,26 +109,28 @@ namespace master {
                     StringFormat::None
                 ),
                 enum_property(
-                    "control-code",
+                    "operation-type",
                     {
-                        opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::NUL),
-                        opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::NUL_CANCEL),
-                        opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::PULSE_ON),
-                        opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::PULSE_ON_CANCEL),
-                        opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::PULSE_OFF),
-                        opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::PULSE_OFF_CANCEL),
-                        opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::LATCH_ON),
-                        opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::LATCH_ON_CANCEL),
-                        opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::LATCH_OFF),
-                        opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::LATCH_OFF_CANCEL),
-                        opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::CLOSE_PULSE_ON),
-                        opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::CLOSE_PULSE_ON_CANCEL),
-                        opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::TRIP_PULSE_ON),
-                        opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::TRIP_PULSE_ON_CANCEL),
+                        opendnp3::OperationTypeSpec::to_string(opendnp3::OperationType::NUL),
+                        opendnp3::OperationTypeSpec::to_string(opendnp3::OperationType::LATCH_OFF),
+                        opendnp3::OperationTypeSpec::to_string(opendnp3::OperationType::LATCH_ON),
+                        opendnp3::OperationTypeSpec::to_string(opendnp3::OperationType::PULSE_OFF),
+                        opendnp3::OperationTypeSpec::to_string(opendnp3::OperationType::PULSE_ON),
                     },
                     Required::yes,
-                    "DNP3 CROB control code",
-                    opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::LATCH_OFF)
+                    "DNP3 CROB 'operation type'",
+                    opendnp3::OperationTypeSpec::to_string(opendnp3::OperationType::LATCH_OFF)
+                ),
+                enum_property(
+                    "trip-close-code",
+                    {
+                        opendnp3::TripCloseCodeSpec::to_string(opendnp3::TripCloseCode::NUL),
+                        opendnp3::TripCloseCodeSpec::to_string(opendnp3::TripCloseCode::TRIP),
+                        opendnp3::TripCloseCodeSpec::to_string(opendnp3::TripCloseCode::CLOSE),
+                    },
+                    Required::yes,
+                    "DNP3 CROB 'trip close code'",
+                    opendnp3::TripCloseCodeSpec::to_string(opendnp3::TripCloseCode::NUL)
                 ),
                 numeric_property<int64_t>(
                     "count",

--- a/plugins/dnp3/src/dnp3/master/ControlSchemaWriteVisitor.h
+++ b/plugins/dnp3/src/dnp3/master/ControlSchemaWriteVisitor.h
@@ -6,8 +6,6 @@
 #include <adapter-util/config/SchemaWriteVisitorBase.h>
 #include <adapter-util/util/EnumUtil.h>
 
-#include <opendnp3/gen/ControlCode.h>
-
 namespace adapter {
 namespace dnp3 {
 namespace master {

--- a/plugins/dnp3/src/dnp3/master/MeasurementSchemaWriteVisitor.h
+++ b/plugins/dnp3/src/dnp3/master/MeasurementSchemaWriteVisitor.h
@@ -6,8 +6,6 @@
 #include <adapter-util/config/SchemaWriteVisitorBase.h>
 #include <adapter-util/util/EnumUtil.h>
 
-#include <opendnp3/gen/ControlCode.h>
-
 namespace adapter {
 namespace dnp3 {
 namespace master {

--- a/plugins/dnp3/src/dnp3/master/Plugin.cpp
+++ b/plugins/dnp3/src/dnp3/master/Plugin.cpp
@@ -2,7 +2,7 @@
 #include "Plugin.h"
 
 #include <opendnp3/master/DefaultMasterApplication.h>
-#include <opendnp3/LogLevels.h>
+#include <opendnp3/logging/LogLevels.h>
 
 #include <adapter-util/ConfigStrings.h>
 #include <adapter-util/ProfileInfo.h>

--- a/plugins/dnp3/src/dnp3/master/SOEHandler.cpp
+++ b/plugins/dnp3/src/dnp3/master/SOEHandler.cpp
@@ -42,7 +42,7 @@ namespace dnp3 {
             process_any(values, this->counter_handlers);
         }
 
-        void SOEHandler::begin_fragment(const opendnp3::ResponseInfo& info)
+        void SOEHandler::BeginFragment(const opendnp3::ResponseInfo& info)
         {
             if(info.fir)
             {
@@ -51,7 +51,7 @@ namespace dnp3 {
             }
         }
 
-        void SOEHandler::end_fragment(const opendnp3::ResponseInfo& info)
+        void SOEHandler::EndFragment(const opendnp3::ResponseInfo& info)
         {
             if(info.fin)
             {

--- a/plugins/dnp3/src/dnp3/master/SOEHandler.h
+++ b/plugins/dnp3/src/dnp3/master/SOEHandler.h
@@ -53,10 +53,7 @@ namespace dnp3 {
                          const opendnp3::ICollection<opendnp3::Indexed<opendnp3::BinaryCommandEvent>>& values) override {}
 
             void Process(const opendnp3::HeaderInfo& info,
-                         const opendnp3::ICollection<opendnp3::Indexed<opendnp3::AnalogCommandEvent>>& values) override {}
-
-            void Process(const opendnp3::HeaderInfo& info,
-                         const opendnp3::ICollection<opendnp3::Indexed<opendnp3::SecurityStat>>& values) override {}
+                         const opendnp3::ICollection<opendnp3::Indexed<opendnp3::AnalogCommandEvent>>& values) override {}            
 
             void Process(const opendnp3::HeaderInfo& info,
                          const opendnp3::ICollection<opendnp3::DNPTime>& values) override {}
@@ -95,9 +92,9 @@ namespace dnp3 {
             }
 
         private:
-            void begin_fragment(const opendnp3::ResponseInfo& info) override;
+            void BeginFragment(const opendnp3::ResponseInfo& info) override;
 
-            void end_fragment(const opendnp3::ResponseInfo& info) override;
+            void EndFragment(const opendnp3::ResponseInfo& info) override;
 
             std::vector<std::function<void()>> start_handlers;
 

--- a/plugins/dnp3/src/dnp3/outstation/CommandHandler.h
+++ b/plugins/dnp3/src/dnp3/outstation/CommandHandler.h
@@ -60,9 +60,9 @@ namespace dnp3 {
             void add_handler(uint16_t index, const ao_handler_t& handler) override;
 
         protected:
-            void begin() override {}
+            void Begin() override {}
 
-            void end() override {}
+            void End() override {}
         };
     }
 }

--- a/plugins/dnp3/src/dnp3/outstation/ControlConfigReadVisitor.cpp
+++ b/plugins/dnp3/src/dnp3/outstation/ControlConfigReadVisitor.cpp
@@ -2,26 +2,28 @@
 #include "ControlConfigReadVisitor.h"
 #include "dnp3/ConfigStrings.h"
 
-#include <opendnp3/gen/ControlCode.h>
-
 namespace adapter {
 namespace dnp3 {
     namespace outstation {
 
-        std::map<opendnp3::ControlCode, bool> read_bool_mapping(const YAML::Node& node)
+        std::map<ControlKey, bool> read_bool_mapping(const YAML::Node& node)
         {
-            std::map<opendnp3::ControlCode, bool> mapping;
+            std::map<ControlKey, bool> mapping;
             util::yaml::foreach (
                 util::yaml::require(node, util::keys::mapping),
                 [&mapping](const YAML::Node& elem) {
-                    const auto code = opendnp3::ControlCodeSpec::from_string(util::yaml::require_string(elem, keys::control_code));
+                    ControlKey key {
+                        opendnp3::OperationTypeSpec::from_string(util::yaml::require_string(elem, keys::operation_type)),
+                        opendnp3::TripCloseCodeSpec::from_string(util::yaml::require_string(elem, keys::trip_close_code)),
+                    };                    
+
                     const auto value = util::yaml::require(elem, util::keys::value).as<bool>();
 
-                    if (mapping.find(code) != mapping.end()) {
-                        throw api::Exception(elem.Mark(), "Duplicate control code in mapping: ", opendnp3::ControlCodeSpec::to_string(code));
+                    if (mapping.find(key) != mapping.end()) {
+                        throw api::Exception(elem.Mark(), "Duplicate control mapping, op type = ", opendnp3::OperationTypeSpec::to_string(key.first), " tcc = ", opendnp3::TripCloseCodeSpec::to_string(key.second));
                     }
 
-                    mapping[code] = value;
+                    mapping[key] = value;
                 });
             return mapping;
         }

--- a/plugins/dnp3/src/dnp3/outstation/ControlConfigReadVisitor.h
+++ b/plugins/dnp3/src/dnp3/outstation/ControlConfigReadVisitor.h
@@ -16,8 +16,11 @@ namespace dnp3 {
 
         /// -----  Helper methods implemented in the cpp -------
 
+        using ControlKey = std::pair<opendnp3::OperationType, opendnp3::TripCloseCode>;
+
+
         // convert from dnp3 control code to boolean
-        std::map<opendnp3::ControlCode, bool> read_bool_mapping(const YAML::Node& node);
+        std::map<ControlKey, bool> read_bool_mapping(const YAML::Node& node);
 
         // convert from DNP3 AO value to raw enum value
         std::map<int, int> read_enum_mapping(const YAML::Node& node, google::protobuf::EnumDescriptor const* descriptor);
@@ -168,8 +171,8 @@ namespace dnp3 {
                 this->config.add_handler(
                     util::yaml::require_integer<uint16_t>(node, util::keys::index),
                     [action, accessor, data = this->shared_data, mapping = read_bool_mapping(node)](api::IPublisher& publisher, const opendnp3::ControlRelayOutputBlock& crob, api::Logger& logger) -> opendnp3::CommandStatus {
-                        // first determine if there's a mapping
-                        const auto iter = mapping.find(crob.functionCode);
+                        // first determine if there's a mapping                    
+                        const auto iter = mapping.find(ControlKey{ crob.opType, crob.tcc });
                         if (iter == mapping.end()) {
                             logger.info("No enum mapping for CROB function: ", crob.rawCode);
                             return opendnp3::CommandStatus::NOT_SUPPORTED;

--- a/plugins/dnp3/src/dnp3/outstation/ControlSchemaWriteVisitor.cpp
+++ b/plugins/dnp3/src/dnp3/outstation/ControlSchemaWriteVisitor.cpp
@@ -8,6 +8,9 @@
 #include "dnp3/generated/CommandSourceType.h"
 #include "dnp3/generated/ProfileAction.h"
 
+#include <opendnp3/gen/OperationType.h>
+#include <opendnp3/gen/TripCloseCode.h>
+
 using namespace adapter::schema;
 
 namespace adapter {
@@ -46,26 +49,28 @@ namespace outstation {
                     "CROBs to map to the boolean value",
                     Object({
                         enum_property(
-                            "control_code",
+                            "operation-type",
                             {
-                                opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::NUL),
-                                opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::NUL_CANCEL),
-                                opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::PULSE_ON),
-                                opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::PULSE_ON_CANCEL),
-                                opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::PULSE_OFF),
-                                opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::PULSE_OFF_CANCEL),
-                                opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::LATCH_ON),
-                                opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::LATCH_ON_CANCEL),
-                                opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::LATCH_OFF),
-                                opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::LATCH_OFF_CANCEL),
-                                opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::CLOSE_PULSE_ON),
-                                opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::CLOSE_PULSE_ON_CANCEL),
-                                opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::TRIP_PULSE_ON),
-                                opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::TRIP_PULSE_ON_CANCEL),
+                                opendnp3::OperationTypeSpec::to_string(opendnp3::OperationType::NUL),
+                                opendnp3::OperationTypeSpec::to_string(opendnp3::OperationType::LATCH_ON),
+                                opendnp3::OperationTypeSpec::to_string(opendnp3::OperationType::LATCH_OFF),
+                                opendnp3::OperationTypeSpec::to_string(opendnp3::OperationType::PULSE_OFF),
+                                opendnp3::OperationTypeSpec::to_string(opendnp3::OperationType::PULSE_ON),
                             },
                             Required::yes,
-                            "DNP3 CROB control code",
-                            opendnp3::ControlCodeSpec::to_string(opendnp3::ControlCode::LATCH_OFF)
+                            "DNP3 CROB 'operation type'",
+                            opendnp3::OperationTypeSpec::to_string(opendnp3::OperationType::LATCH_OFF)
+                        ),
+                        enum_property(
+                            "trip-close-code",
+                            {
+                                opendnp3::TripCloseCodeSpec::to_string(opendnp3::TripCloseCode::NUL),
+                                opendnp3::TripCloseCodeSpec::to_string(opendnp3::TripCloseCode::TRIP),
+                                opendnp3::TripCloseCodeSpec::to_string(opendnp3::TripCloseCode::CLOSE),
+                            },
+                            Required::yes,
+                            "DNP3 CROB 'trip close code'",
+                            opendnp3::TripCloseCodeSpec::to_string(opendnp3::TripCloseCode::NUL)
                         ),
                         bool_property(
                             util::keys::value,

--- a/plugins/dnp3/src/dnp3/outstation/ControlSchemaWriteVisitor.h
+++ b/plugins/dnp3/src/dnp3/outstation/ControlSchemaWriteVisitor.h
@@ -6,8 +6,6 @@
 #include <adapter-util/config/SchemaWriteVisitorBase.h>
 #include <adapter-util/util/EnumUtil.h>
 
-#include <opendnp3/gen/ControlCode.h>
-
 namespace adapter {
 namespace dnp3 {
 namespace outstation {

--- a/plugins/dnp3/src/dnp3/outstation/MeasurementSchemaWriteVisitor.h
+++ b/plugins/dnp3/src/dnp3/outstation/MeasurementSchemaWriteVisitor.h
@@ -6,8 +6,6 @@
 #include <adapter-util/config/SchemaWriteVisitorBase.h>
 #include <adapter-util/util/EnumUtil.h>
 
-#include <opendnp3/gen/ControlCode.h>
-
 namespace adapter {
 namespace dnp3 {
 namespace outstation {

--- a/plugins/dnp3/src/dnp3/outstation/Plugin.cpp
+++ b/plugins/dnp3/src/dnp3/outstation/Plugin.cpp
@@ -6,7 +6,7 @@
 #include <adapter-util/config/generated/TypedModelVisitors.h>
 #include <adapter-util/util/YAMLTemplate.h>
 
-#include <opendnp3/LogLevels.h>
+#include <opendnp3/logging/LogLevels.h>
 #include <opendnp3/outstation/DatabaseConfig.h>
 #include <opendnp3/outstation/DefaultOutstationApplication.h>
 


### PR DESCRIPTION
This changes the DNP3 plugin YAML to break apart the old `ControlCode` into `OperationType` and `TripCloseCode`.

Also removed the checksum calc in the cmake fetch since it's over https and just complicates things.