### PR TITLE
Fix DNP3 master empty events

### DIFF
--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -31,7 +31,6 @@ function(clang_format target)
 
         endforeach()
         set_property(GLOBAL PROPERTY CLANG_FORMAT_FILES "${all_source_files}")
-        message(STATUS ${CLANG_FORMAT_FILES})
     else()
         message(WARNING "Target ${target} does not exists.")
     endif()

--- a/deps/opendnp3.cmake
+++ b/deps/opendnp3.cmake
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     opendnp3
     GIT_REPOSITORY https://github.com/dnp3/opendnp3.git
-    GIT_TAG        3.0.3
+    GIT_TAG        3.0.4
 )
 
 FetchContent_GetProperties(opendnp3)

--- a/plugins/dnp3/src/dnp3/master/SOEHandler.cpp
+++ b/plugins/dnp3/src/dnp3/master/SOEHandler.cpp
@@ -8,12 +8,12 @@ namespace dnp3 {
     namespace master {
 
         template <class T>
-        void
-        process_any(const opendnp3::ICollection<opendnp3::Indexed<T>>& values, SOEHandler::handler_map<T>& map)
+        void SOEHandler::process_any(const opendnp3::ICollection<opendnp3::Indexed<T>>& values, SOEHandler::handler_map<T>& map)
         {
             auto process = [&](const opendnp3::Indexed<T>& pair) {
                 auto it = map.find(pair.index);
                 if (it != map.end()) {
+                    has_changes = true;
                     for(auto& handler : it->second)
                     {
                         handler(pair.value);
@@ -46,6 +46,7 @@ namespace dnp3 {
         {
             if(info.fir)
             {
+                has_changes = false;
                 for (auto& action : this->start_handlers)
                     action();
             }
@@ -53,7 +54,7 @@ namespace dnp3 {
 
         void SOEHandler::EndFragment(const opendnp3::ResponseInfo& info)
         {
-            if(info.fin)
+            if(info.fin && has_changes)
             {
                 for (auto& action : this->end_handlers)
                     action();

--- a/plugins/dnp3/src/dnp3/master/SOEHandler.h
+++ b/plugins/dnp3/src/dnp3/master/SOEHandler.h
@@ -93,8 +93,10 @@ namespace dnp3 {
 
         private:
             void BeginFragment(const opendnp3::ResponseInfo& info) override;
-
             void EndFragment(const opendnp3::ResponseInfo& info) override;
+
+            template <class T>
+            void process_any(const opendnp3::ICollection<opendnp3::Indexed<T>>& values, handler_map<T>& map);
 
             std::vector<std::function<void()>> start_handlers;
 
@@ -103,6 +105,8 @@ namespace dnp3 {
             handler_map<opendnp3::Counter> counter_handlers;
 
             std::vector<std::function<void()>> end_handlers;
+
+            bool has_changes = false;
         };
     }
 }


### PR DESCRIPTION
Instead of #105, this could solve the issue raised by Cory, although I'm still not convinced it's the best solution.

The `SOEHandler` now checks if it modified something on the OpenFMB profile before publishing it.

I foresee these limitations:
- If two profiles are linked to the same poll and only one of them fills the OpenFMB profile, both profiles will be published.
- If DNP3 events are received but map to the same OpenFMB values (e.g. multiple analog input values that map to the same enum value), it will publish the events, even if the message is identical to the previous one.
- If a profile only has static data not read from DNP3 (e.g. only constant strings), it will never publish.