### PR TITLE
Add ability to push to dockerhub

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,6 @@
 name: "Build"
 on:
   push:
-    branches:
-      - "default"
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Add restriction so that the workflow on runs in the develop branch
- Add steps for pushing tagged images for each arch to docker hub
- Add steo to generate and push a manifest to docker hub to create a single multiarch image

** DO NOT MERGE UNTIL**
- secrets have been added for the docker hub username and docker hub token