### PR TITLE
Add a list of dependencies and their licenses

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -39,7 +39,7 @@ pkgs.callPackage ({ninja, cmake, protobuf3_6, openssl, libpcap, boost166, asio, 
     catch2
     deps.libnats-c
     deps.libpq
-    deps.libyamlcpp
+    deps.libyaml-cpp
     deps.argagg
     deps.cppcodec
     deps.exe4cpp

--- a/dep_licenses.md
+++ b/dep_licenses.md
@@ -1,0 +1,33 @@
+<!--
+SPDX-FileCopyrightText: 2021 Open Energy Solutions Inc
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Dependency Licenses
+
+This table contains the list of open source dependencies which are linked into
+the OpenFMB Adapter project and their respective licenses in the default build.
+
+This should be updated as dependencies are added or removed.
+
+| name          | license (spdx id) |
+|---------------|-------------------|
+| boost         | BSL-1.0           |
+| exe4cpp       | BSD-3-Clause      |
+| ser4cpp       | BSD-3-Clause      |
+| log4cpp       | BSD-3-Clause      |
+| opendnp3      | Apache-2.0        |
+| modbus-cpp    | Apache-2.0        |
+| protobuf      | BSD-3-Clause      |
+| yaml-cpp      | MIT               |
+| Catch2        | BSL-1.0           |
+| asio          | BSL-1.0           |
+| libpq         | PostgreSQL        |
+| argagg        | MIT               |
+| spdlog        | MIT               |
+| cppcodec      | MIT               |
+| openssl       | OpenSSL           |
+| paho-mqtt-c   | EPL-1.0           |
+| paho-mqtt-cpp | EPL-1.0           |
+| nats-c        | Apache-2.0        |

--- a/nix/allpkgs.nix
+++ b/nix/allpkgs.nix
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Open Energy Solutions Inc
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{ pkgs ? import ./nixpkgs.nix{} }:
+
+import ./packages.nix { pkgs = pkgs; } // pkgs

--- a/nix/libyaml-cpp/default.nix
+++ b/nix/libyaml-cpp/default.nix
@@ -8,7 +8,7 @@
 pkgs.callPackage({ stdenv, fetchFromGitHub, cmake }:
   stdenv.mkDerivation rec {
     pname = "libyaml-cpp";
-    version = "0.6.4-git";
+    version = "0.6.4";
   
     src = fetchFromGitHub {
       owner = "jbeder";

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -13,7 +13,7 @@ let
     exe4cpp = callPackage ./exe4cpp/default.nix { };
     libnats-c = callPackage ./libnats-c/default.nix { };
     libpq = callPackage ./libpq/default.nix { };
-    libyamlcpp = callPackage ./libyaml-cpp/default.nix { };
+    libyaml-cpp = callPackage ./libyaml-cpp/default.nix { };
     log4cpp = callPackage ./log4cpp/default.nix { };
     modbus-cpp = callPackage ./modbus-cpp/default.nix { };
     #goose-cpp = callPackage ./modbus-cpp.nix { };

--- a/scripts/dep_licenses.sh
+++ b/scripts/dep_licenses.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2021 Open Energy Solutions Inc
+#
+# SPDX-License-Identifier: Apache-2.0
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+$DIR/list_deps.sh | xargs nix-env -qa --meta --json -f $DIR/../nix/allpkgs.nix

--- a/scripts/list_deps.sh
+++ b/scripts/list_deps.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2021 Open Energy Solutions Inc
+#
+# SPDX-License-Identifier: Apache-2.0
+
+drv="$( nix-instantiate default.nix )"
+drvRefs="$( echo "$drv" | xargs nix-store -q --references )"
+#( echo "$drvRefs" | grep '[.]drv$' | xargs nix-store -q --outputs ;
+#  echo "$drvRefs" | grep -v '[.]drv$' ) |
+#xargs nix-store -r | xargs nix-store -qR
+
+depNames="$(echo "$drvRefs" | grep '[.]drv$' | xargs nix show-derivation | jq '.[] | .env.name' )"
+echo "$depNames"
+


### PR DESCRIPTION
Adds dependency licenses in a nice markdown table, built from a list of dependencies generated with shell scripting and nix.

In the future some more automation could be done to automatically list the spdx license ids from nix package metadata and some work was done here with that in mind, but after several speed humps this was a faster way to get it done.